### PR TITLE
Update BundleFile to handle '\' in Files and URIs (#333)

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/BundleFile.scala
@@ -20,14 +20,15 @@ import scala.util.Try
   */
 object BundleFile {
   implicit def apply(uri: String): BundleFile = {
-    apply(new URI(uri))
+    apply(new URI(unbackslash(uri)))
   }
 
+
   implicit def apply(file: File): BundleFile = {
-    val uri = if(file.getPath.endsWith(".zip")) {
-      new URI(s"jar:file:${file.getAbsolutePath}")
+    val uri: String = if (file.getPath.endsWith(".zip")) {
+      s"jar:${file.toURI.toString}"
     } else {
-      new URI(s"file:$file")
+      file.toURI.toString
     }
 
     apply(uri)
@@ -35,16 +36,26 @@ object BundleFile {
 
   implicit def apply(uri: URI): BundleFile = {
     val env = Map("create" -> "true").asJava
+    val uriSafe = new URI(unbackslash(uri.toString))
 
-    val (fs, path) = uri.getScheme match {
+    val (fs, path) = uriSafe.getScheme match {
       case "file" =>
-        (FileSystems.getDefault, FileSystems.getDefault.getPath(uri.getPath))
+        (FileSystems.getDefault, FileSystems.getDefault.getPath(uriSafe.getPath))
       case "jar" =>
-        val zfs = FileSystems.newFileSystem(uri, env)
+        val zfs = FileSystems.newFileSystem(uriSafe, env)
         (zfs, zfs.getPath("/"))
     }
 
     apply(fs, path)
+  }
+
+  /** Replace all backslashes with forward slashes, to handle Windows file paths in URI construction
+    *
+    * @param uri String representing a URI
+    * @return String containing no backslashes.
+    */
+  private def unbackslash(uri: String): String = {
+    uri.replace('\\', '/')
   }
 }
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -107,6 +107,21 @@ class BundleSerializationSpec extends FunSpec {
           }
         }
       }
+
+      describe("with a backslash'd path for a linear regression") {
+        it("serializes and deserializes from a path containing '\\' separators") {
+          val uri = s"$prefix:${TestUtil.baseDir}/lr_bundle.$format$suffix".replace('/', '\\')
+          for(file <- managed(BundleFile(uri))) {
+            lr.writeBundle.name("my_bundle").
+              format(format).
+              save(file)
+
+            val bundleRead = file.loadBundle().get
+
+            assert(lr == bundleRead.root)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
* Update BundleFile to handle '\' in Files and URIs

When mleap is built in Windows, operations related to getting a path or
string from a File or URI will include `\` characters.  This includes
calls to
`file.{toString(),getPath(),toPath().toString(),toURI().toString(),toPath().toUri().toString()}`.
To be defensive, we create new URIs from all inputs, with backslashes
replaced by forward slashes.

* Update utility function with null check.

* Run `unbackslash()` without null check, as we want to throw on invalid input.

* Add docstring to `unbackslash` method.